### PR TITLE
Fix IntelliCode constructor invocation

### DIFF
--- a/Copilot/Suggestions.cs
+++ b/Copilot/Suggestions.cs
@@ -96,23 +96,26 @@ namespace JeffPires.VisualChatGPTStudio.Copilot
             ParameterInfo[] parameters = obj2Constructor.GetParameters();
             object[] args = new object[parameters.Length];
 
-            if (parameters.Length > 0)
+            for (int i = 0; i < parameters.Length; i++)
             {
-                args[0] = obj;
-            }
+                Type paramType = parameters[i].ParameterType;
 
-            if (parameters.Length > 1)
-            {
-                args[1] = inlineCompletionsInstance;
-            }
-
-            for (int i = 2; i < parameters.Length; i++)
-            {
-                args[i] = parameters[i].HasDefaultValue
-                    ? parameters[i].DefaultValue
-                    : (parameters[i].ParameterType.IsValueType
-                        ? Activator.CreateInstance(parameters[i].ParameterType)
-                        : null);
+                if (paramType == generateResultType)
+                {
+                    args[i] = obj;
+                }
+                else if (paramType == inlineCompletionsType)
+                {
+                    args[i] = inlineCompletionsInstance;
+                }
+                else
+                {
+                    args[i] = parameters[i].HasDefaultValue
+                        ? parameters[i].DefaultValue
+                        : (paramType.IsValueType
+                            ? Activator.CreateInstance(paramType)
+                            : null);
+                }
             }
 
             object obj2 = obj2Constructor.Invoke(args);

--- a/Copilot/Suggestions.cs
+++ b/Copilot/Suggestions.cs
@@ -96,12 +96,23 @@ namespace JeffPires.VisualChatGPTStudio.Copilot
             ParameterInfo[] parameters = obj2Constructor.GetParameters();
             object[] args = new object[parameters.Length];
 
-            args[0] = obj;
-            args[1] = inlineCompletionsInstance;
+            if (parameters.Length > 0)
+            {
+                args[0] = obj;
+            }
+
+            if (parameters.Length > 1)
+            {
+                args[1] = inlineCompletionsInstance;
+            }
 
             for (int i = 2; i < parameters.Length; i++)
             {
-                args[i] = parameters[i].HasDefaultValue ? parameters[i].DefaultValue : (parameters[i].ParameterType.IsValueType ? Activator.CreateInstance(parameters[i].ParameterType) : null);
+                args[i] = parameters[i].HasDefaultValue
+                    ? parameters[i].DefaultValue
+                    : (parameters[i].ParameterType.IsValueType
+                        ? Activator.CreateInstance(parameters[i].ParameterType)
+                        : null);
             }
 
             object obj2 = obj2Constructor.Invoke(args);

--- a/Copilot/Suggestions.cs
+++ b/Copilot/Suggestions.cs
@@ -91,7 +91,14 @@ namespace JeffPires.VisualChatGPTStudio.Copilot
 
             object obj = Activator.CreateInstance(generateResultType, proposalCollection, null);
 
-            ConstructorInfo obj2Constructor = inlineCompletionSuggestion.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic).First();
+            ConstructorInfo[] constructors = inlineCompletionSuggestion.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic);
+            ConstructorInfo obj2Constructor = constructors
+                .FirstOrDefault(c =>
+                {
+                    ParameterInfo[] p = c.GetParameters();
+                    return p.Any(x => x.ParameterType.IsAssignableFrom(generateResultType)) &&
+                           p.Any(x => x.ParameterType == inlineCompletionsType);
+                }) ?? constructors.First();
 
             ParameterInfo[] parameters = obj2Constructor.GetParameters();
             object[] args = new object[parameters.Length];
@@ -100,7 +107,7 @@ namespace JeffPires.VisualChatGPTStudio.Copilot
             {
                 Type paramType = parameters[i].ParameterType;
 
-                if (paramType == generateResultType)
+                if (paramType == generateResultType || paramType.IsAssignableFrom(generateResultType))
                 {
                     args[i] = obj;
                 }

--- a/Copilot/Suggestions.cs
+++ b/Copilot/Suggestions.cs
@@ -93,16 +93,18 @@ namespace JeffPires.VisualChatGPTStudio.Copilot
 
             ConstructorInfo obj2Constructor = inlineCompletionSuggestion.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic).First();
 
-            object obj2;
+            ParameterInfo[] parameters = obj2Constructor.GetParameters();
+            object[] args = new object[parameters.Length];
 
-            if (obj2Constructor.GetParameters().Length == 2)
+            args[0] = obj;
+            args[1] = inlineCompletionsInstance;
+
+            for (int i = 2; i < parameters.Length; i++)
             {
-                obj2 = inlineCompletionSuggestion.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic).First().Invoke([obj, inlineCompletionsInstance]);
+                args[i] = parameters[i].HasDefaultValue ? parameters[i].DefaultValue : (parameters[i].ParameterType.IsValueType ? Activator.CreateInstance(parameters[i].ParameterType) : null);
             }
-            else
-            {
-                obj2 = inlineCompletionSuggestion.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic).First().Invoke([obj, inlineCompletionsInstance, 0]);
-            }
+
+            object obj2 = obj2Constructor.Invoke(args);
 
             object value2 = suggestionManagerType.GetValue(inlineCompletionsInstance);
 


### PR DESCRIPTION
## Summary
- handle changing parameter counts for Visual Studio IntelliCode constructor when showing autocomplete suggestions

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2cc4d65c8321b0cb5352a193c61e